### PR TITLE
Refine modal migration plan and add modal specs

### DIFF
--- a/doc/modal_component_plan.md
+++ b/doc/modal_component_plan.md
@@ -1,0 +1,139 @@
+# Modal Components React 移行詳細計画
+
+## 1. 目的
+- 既存の `index.html` に散在する 8 種類のモーダル（開始、ガイド、リアルタイム入力、景品設定、リアグ設定、ガチャ削除、アイテム削除、保存オプション）を React + Tailwind CSS へ集約し、共通のベースコンポーネントを構築する。旧カタログ貼り付けモーダルは導線がなくなったため、React 移行時に削除する。【F:index.html†L291-L517】
+- `modal` / `dialog` クラスに依存する現在の表示・レイアウト・スタッキング制御を Tailwind ユーティリティと React 状態管理へ移し、重複コードとグローバル副作用を削減する。【F:index.css†L31-L141】【F:index.html†L1727-L1758】
+- モーダル機能を `ModalProvider` として抽象化し、今後追加されるダイアログでも再利用できる設計を整える。React 全体構成のモーダルホスト方針と整合させ、各機能フォルダで具体モーダルを保守できるようにする。【F:doc/react_migration_plan.md†L174-L176】
+
+## 2. 現状整理
+- **Start Modal (`#startModal`)**: TXT/JSON 読込と新規開始タイル、ファイル入力、閉じるボタンを提供するオンボーディング入口。【F:index.html†L291-L325】
+- **Catalog Paste (`#catalogModal`)**: 現在は導線がなく、React 移行後に削除予定。カタログ解析ロジックは別のインポート手段へ統合する。【F:index.html†L328-L344】
+- **Guide (`#guideModal`)**: 次のステップ案内のみのシンプルな承諾ダイアログ。【F:index.html†L346-L357】
+- **Live Paste (`#liveModal`)**: リアルタイム結果テキスト入力と反映ボタンを提供する大きなテキストエリアモーダル。【F:index.html†L360-L371】
+- **Prize Settings (`#imageModal`, 移行後 `PrizeSettingsDialog`)**: 対象情報、プレビュー、ファイル選択、保存・閉じる操作をまとめた最大幅 880px の 2 カラムレイアウトモーダル。React 移行時に景品名・レアリティ入力、プレビュー、ファイル選択、「ピックアップ対象」「コンプリートガチャ対象」トグル、リアグ設定起動ボタンを内包する仕様へ拡張する。【F:index.html†L374-L415】
+- **Riagu (`#riaguModal`)**: リアグ原価・タイプ入力、保存/解除/閉じるボタンを備える設定モーダル。【F:index.html†L417-L435】
+- **Gacha Delete (`#deleteModal`)**: ガチャ削除確認とターゲット表示、キャンセル/削除ボタンを持つ確認ダイアログ。【F:index.html†L439-L448】
+- **Item Delete (`#itemDeleteModal`)**: アイテム削除確認、警告表示、キャンセル/削除ボタン。【F:index.html†L452-L467】
+- **Save Options (`#saveOptionModal`)**: 保存手段カード、アップロード結果表示、閉じる操作で構成される複合モーダル。【F:index.html†L474-L517】
+
+### 2.2 現在の表示制御
+- `.modal` は `display:none` → `.show` で grid 表示、`position:fixed`、オーバーレイ背景を提供し、`.dialog` はボーダー・角丸・影などのベーススタイルを担っている。【F:index.css†L124-L130】
+- `open(modal)` / `close(modal)` 関数がクラス切り替え・`aria-hidden` 更新・モーダル数カウント・`body.modal-open` の付与を行い、FAB の表示抑止など他機能へ影響している。【F:index.html†L1727-L1758】【F:index.css†L424-L437】
+- DOMContentLoaded 後に各モーダルへ開閉イベントがバインドされており、外部スクリプトからも `openXxxModal` 系関数で直接操作される構造になっている。【F:index.html†L838-L929】【F:index.html†L1751-L1758】【F:index.html†L1207-L1334】
+
+### 2.3 技術的課題
+- 開閉状態がグローバル関数と DOM 参照に依存し、React 化時に二重管理が発生しやすい。
+- スタイルは共通 CSS クラスで固定されており、Tailwind へ移行する際にテーマトークン（背景・影・ボタン）を再定義する必要がある。【F:index.css†L2-L45】
+- モーダルごとにフォーム状態やサービス呼び出しを直接参照しており、React ストアや Hook への置き換え計画が必要。
+
+## 3. React + Tailwind への移行方針
+1. `apps/web/src/components/modal/` に `ModalRoot`, `ModalOverlay`, `ModalPanel` などのベースコンポーネントを実装し、Tailwind プリミティブで共通スタイルを定義する。【F:doc/react_migration_plan.md†L21-L37】【F:doc/react_migration_plan.md†L174-L176】
+2. `ModalProvider`（Context + reducer）でモーダルスタックを管理し、`useModal()` Hook から `push`, `replace`, `pop` 操作を提供する。`body.modal-open` の代わりに `useEffect` でスクロールロックと `aria-hidden` 管理を行う。【F:index.html†L1727-L1758】
+3. Tailwind テーマへ `bg-surface`, `bg-surface-muted`, `border-border`, `shadow-elevated`, `text-muted`, `accent` などを追加し、既存 CSS 変数を移植する。【F:index.css†L2-L45】
+4. 各具体モーダルは `apps/web/src/features/<domain>/dialogs/` に配置し、ドメインストア・サービス Hook と連携する。既存関数のロジックは対応する feature hook へ移す。
+
+## 4. データモデリング
+### 4.1 ベースモーダル型
+```ts
+export type ModalSize = 'sm' | 'md' | 'lg' | 'xl';
+
+export interface ModalBaseProps<T = unknown> {
+  id: string;
+  title: string;
+  size?: ModalSize;
+  description?: string;
+  dismissible?: boolean;
+  payload?: T;
+  onClose?: () => void;
+}
+```
+- `size` で `max-w-md`〜`max-w-5xl` を制御し、従来の `.dialog` 幅（`min(880px,96vw)`）を `lg` / `xl` バリアントに対応させる。【F:index.css†L127-L130】
+- `payload` は `ModalProvider` が push 時に渡すデータで、削除確認などが対象 ID を受け取れるようにする。【F:index.html†L1207-L1316】
+
+### 4.2 コンテキスト状態
+```ts
+interface ModalStackEntry {
+  component: React.ComponentType<any>;
+  props: ModalBaseProps<any>;
+}
+
+interface ModalState {
+  stack: ModalStackEntry[];
+  modalCount: number; // body スクロール制御用
+}
+```
+- `modalCount` を維持して複数同時表示にも対応。既存の `modalCount` ロジックを React に置き換える。【F:index.html†L1727-L1739】
+- `ModalProvider` は `useReducer` で `push`, `pop`, `replace`, `dismissAll` を処理し、`useEffect` で `document.body.dataset.modalOpen = stack.length ? '1' : '0'` を更新する。
+
+## 5. コンポーネント分解計画
+### 5.1 共通コンポーネント
+- `ModalRoot`: ポータル先（`#modal-root`）にレンダリングし、背景オーバーレイと ARIA 属性を制御する。
+- `ModalOverlay`: `fixed inset-0 bg-black/65 backdrop-blur-sm transition-opacity` でフェードイン/アウト。クリックで `onDismiss` を呼ぶ。
+- `ModalPanel`: サイズバリアントごとの `max-w` と `p-6` を適用し、`rounded-2xl border border-border bg-surface shadow-elevated` で統一する。【F:index.css†L31-L45】【F:index.css†L124-L130】
+- `ModalHeader`, `ModalBody`, `ModalFooter`: タイトル・説明文・ボタンエリアの配置ユーティリティ。`space-y-4` や `flex justify-end gap-3` を提供。
+
+### 5.2 機能別モーダル
+1. **StartWizardDialog** (`features/onboarding/dialogs/StartWizardDialog.tsx`)
+   - Props: `onPickTxt`, `onPickJson`, `onCreateNew`, `onDismiss`。
+   - `StartTile` サブコンポーネントでカード UI を再現し、`grid grid-cols-1 sm:grid-cols-3 gap-4` を採用。【F:index.html†L297-L315】
+   - ファイル入力は `HiddenFileField` コンポーネントへ抽象化する。
+2. **CatalogImportDialog**（削除対象）
+   - 旧カタログ貼り付けモーダルの React 実装は作成せず、ガチャ一括登録は別のインポート UI（`features/importers/pages/CatalogUploadPage` など）へ統合する。
+   - 既存の `parseCatalogModal` 関連ハンドラは廃止し、React 移行時に `CatalogImportDialog` へのルーティングを削除する。【F:index.html†L328-L344】【F:index.html†L842-L854】
+3. **GuideInfoDialog** (`features/onboarding/dialogs/GuideInfoDialog.tsx`)
+   - シンプルな情報 + プライマリボタン。`text-muted` 表現。【F:index.html†L346-L356】
+4. **LivePasteDialog** (`features/realtime/dialogs/LivePasteDialog.tsx`)
+   - `liveText`, `onApply`。`textarea` とアクションボタンを `flex justify-end gap-3` に配置。【F:index.html†L360-L369】
+5. **PrizeSettingsDialog** (`features/items/dialogs/PrizeSettingsDialog.tsx`)
+   - Context: `usePrizeSettings(gachaId, rarityId, itemCode)` で景品名、レアリティ、プレビュー情報、トグル状態を取得する。
+   - レイアウト: `grid gap-6 lg:grid-cols-[minmax(0,1fr),minmax(0,1fr)]` でプレビュー（左）とファイル選択（右）を分割し、フォームヘッダーに景品名・レアリティ入力を配置。プレビュー枠は `bg-surface-muted border border-border rounded-2xl p-4` で画像とメタ情報を表示し、右列に `FileDropZone`、`PickFromLibraryButton` を配置する。【F:index.html†L392-L411】
+   - 「ピックアップ対象」「コンプリートガチャ対象」のトグルスイッチは `Switch` コンポーネントで実装し、状態を `usePrizeSettings` へバインドする。画像 URL フォームは廃止する。
+   - フッターには `SaveButton`, `OpenRiaguDialogButton`, `CloseButton` を並べ、閉じるボタン押下時は確認アラート（「景品設定に戻る」「閉じる」）を表示する。確認アラートは `ModalProvider` の `push` を使い、変更が破棄される旨を明示する。
+6. **RiaguConfigDialog** (`features/riagu/dialogs/RiaguConfigDialog.tsx`)
+   - 入力検証: 数値/文字列。保存・解除・閉じるボタンの配置は `flex justify-end gap-3`。【F:index.html†L424-L435】
+7. **GachaDeleteConfirmDialog** (`features/gacha/dialogs/GachaDeleteConfirmDialog.tsx`)
+   - Props: `gachaId`, `gachaName`, `onConfirm`。
+   - Danger ボタンを `variant="destructive"` で赤系に。【F:index.html†L439-L448】
+8. **ItemDeleteConfirmDialog** (`features/items/dialogs/ItemDeleteConfirmDialog.tsx`)
+   - 警告表示を `text-error` と `bg-error/10 border-error/30` のアラートボックスに変換。【F:index.html†L452-L466】
+9. **SaveOptionsDialog** (`features/users/dialogs/SaveOptionsDialog.tsx`)
+   - 3 カードを `grid sm:grid-cols-3 gap-4` で表示（デバイス保存、shimmy3.com アップロード、Discord 直接送信）。Discord カードは shimmy3.com へ ZIP をアップロードし、そのリンクを Discord リスナーへ転送するフローを説明する。
+   - アップロード結果セクションは `grid grid-cols-[minmax(0,1fr),auto]` でリンクとコピーを整列し、各カードに `CTAButton` を配置する。【F:index.html†L479-L515】
+
+## 6. Tailwind デザイン指針
+- カラートークンは `tailwind.config.ts` の `extend.colors` に `surface`, `surface-muted`, `border`, `accent`, `accent-dark`, `muted` を登録し、既存 CSS 変数と一致させる。【F:index.css†L2-L45】
+- ボタンは `btn` コンポーネント（`inline-flex items-center justify-center font-bold rounded-xl`）で `variant="primary|subtle|ghost|danger|small"` を用意し、既存クラスのスタイルを Tailwind ユーティリティで置換する。【F:index.css†L31-L45】
+- モーダルパネルは `max-w-lg`, `max-w-2xl`, `max-w-4xl`, `max-w-5xl` などのユーティリティを `ModalSize` に対応させる。
+- テキストフィールド/テキストエリアは `rounded-xl border border-border bg-surface-muted px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-accent/40` を標準化する。【F:index.css†L136-L138】
+
+## 7. アクセシビリティ & インタラクション
+- `Dialog` は `role="dialog" aria-modal="true"` を自動付与し、`aria-labelledby` / `aria-describedby` を `ModalHeader` で生成する。【F:index.html†L293-L377】
+- フォーカストラップは Headless UI の `Dialog` もしくは自前の `FocusTrap` Hook を利用し、開閉時に最初のフォーカス可能要素へ移動する。
+- `Esc` キー・オーバーレイクリックでの閉鎖、タブインデックス制御、スクロールロック（`overflow-hidden`）を `ModalProvider` が統合的に管理する。
+- 複数モーダル同時表示時でも最前面だけがフォーカスされるよう z-index を `modal-base (z-50)`、FAB は `z-70` に設定し `body[data-modal-open="1"]` で表示抑止を再現する。【F:index.css†L424-L437】
+
+## 8. 状態とサービス連携
+- Onboarding/Import/Realtime は `useOnboardingFlow`, `useImportJobs`, `useRealtimePaste` などの Hook からモーダルを起動し、完了時に `AppStateStore` を更新する。
+- アイテム画像・リアグ設定・削除系は `ImageAssetStore`, `RiaguStore`, `AppStateStore` の reducer アクションへ接続し、現在の同期ロジックを React 版へ移植する。【F:index.html†L1207-L1334】【F:index.html†L1341-L1679】
+- 保存オプションは `useSaveJob` Hook で ZIP 保存・Blob アップロードを扱い、アップロード結果を Context 経由で共有する。
+
+## 9. 移行ステップ
+1. `ModalProvider` / ベース UI を作成し、Storybook にプレビューを追加。
+2. Onboarding モーダル（Start, Guide）を React へ移植し、既存 DOM から該当セクションを削除。
+3. リアルタイム貼り付けモーダルを React 化し、`parseLiveInput` など既存ユーティリティを Hook へ再配置する。【F:index.html†L360-L371】【F:index.html†L1812-L1820】
+4. カタログ貼り付けモーダルの DOM・イベントバインディングを撤去し、必要なロジックは別ページ用サービスへ移す。【F:index.html†L328-L344】【F:index.html†L842-L854】
+5. 景品設定・リアグ・削除確認モーダルを順次置換し、旧 `openXxxModal` 関数を `ModalProvider` 経由の呼び出しに書き換える。【F:index.html†L374-L1343】
+6. 保存オプションモーダルと FAB 連携を React へ移行し、`body.modal-open` 依存を排除。【F:index.css†L424-L437】
+7. 最後に `index.html` の静的モーダル DOM と関連スクリプトを削除し、Tailwind クラスへの完全移行を確認する。
+
+## 10. テスト計画
+- **ユニットテスト**: `ModalProvider` reducer の push/pop、スクロールロック、副作用を Vitest で検証。
+- **コンポーネントテスト**: React Testing Library で各モーダルのレンダリング、フォーカス移動、ボタン操作、エラーメッセージ表示を確認する。
+- **統合テスト**: Storybook/Chromatic で視覚回帰、Playwright で「アイテムカード → 画像設定モーダル → 保存」「ユーザー保存 → 保存オプション」など主要フローを自動化。【F:index.html†L908-L1018】【F:index.html†L974-L1017】
+- **アクセシビリティ**: axe-core で `role`, `aria-*`, ランドマーク、コントラストを検証。スクリーンリーダーでの読み上げ順を確認。
+
+## 11. リスクと対策
+- **複数モーダルの競合**: Stack 制御の不整合でスクロールロックが解除されない可能性。→ reducer と副作用をテストでカバーし、`finally` 的 cleanup を徹底。
+- **サービス呼び出しの同期漏れ**: React ストア移行時に旧グローバル関数と二重更新が起こる可能性。→ 各機能移行フェーズで旧関数を段階的に削除し、`ModalProvider` からのみ開閉できるようにする。
+- **Tailwind クラス肥大化**: モーダル固有のクラスが散在するとビルドが膨らむ。→ `clsx` + variant パターンを導入し、共通スタイルを `ModalPanel` に集約。
+- **フォーカス制御の欠落**: 自前実装でフォーカストラップが崩れる恐れ。→ Headless UI の `Dialog` をベースとし、最低限 `focus-trap` を導入する。

--- a/doc/modals/catalog_modal_spec.md
+++ b/doc/modals/catalog_modal_spec.md
@@ -1,0 +1,27 @@
+# Catalog Modal（削除対象）仕様書
+
+## 1. 現状概要
+- `#catalogModal` はカタログテキストを貼り付けてガチャとアイテム一覧を初期登録するためのモーダル。【F:index.html†L328-L344】
+- 現在は UI 上の導線が撤去されており、利用頻度がゼロであるため React 移行後は廃止する。
+
+## 2. DOM とスクリプト
+- DOM にはガチャ名入力、テキストエリア、`#catParse` / `#catClose` ボタンが含まれる。【F:index.html†L334-L341】
+- `#catParse` クリック時に `parseCatalogText` を使用して `gCatalogByGacha` を再構築し、`renderTabs()` などを呼び出す。【F:index.html†L1812-L1827】
+- パース成功後は `startDone()` → `close(catalogModal)` → `open(guideModal)` を実行し、ガイドモーダルを表示する。【F:index.html†L1826-L1829】
+- DOMContentLoaded フックで `#catClose` の閉じるイベントがバインドされている。【F:index.html†L1751-L1756】
+
+## 3. React 移行方針
+- React 版ではモーダルとしては廃止し、インポートフローは専用ページ/ウィザードへ移行する。
+- `CatalogImportDialog` コンポーネントは作成せず、既存の `parseCatalogText` 等を `features/importers/services/catalog.ts` へ移管する。
+- `ModalProvider` のスタックからも対象を削除し、`useModal` から参照されないようにする。
+
+## 4. 撤去ステップ
+1. React 化のタイミングで `CatalogImportDialog` を実装しないことを仕様として明記する。
+2. `index.html` の `#catalogModal` DOM と `catalogModal` 変数、`#catParse` ハンドラを削除する。【F:index.html†L328-L341】【F:index.html†L1723-L1756】
+3. `parseCatalogText` / `parseCatalogModal` 関連ユーティリティをページ専用の React サービスへ移し、モーダル依存を排除する。
+4. リリース前に Playwright テストで `#catalogModal` が存在しないことを確認し、旧 UI の遺残がないことを担保する。
+
+## 5. テスト・確認事項
+- Jest/Vitest で `parseCatalogText` の単体テストを維持し、モーダル撤去後もロジックが有効であることを検証する。
+- Start フロー（TXT/JSON 読込・新規作成）がカタログモーダルなしでも完結することを E2E で確認する。
+- ガイドモーダル表示が他のフローから引き続き呼び出せることを確認し、導線欠落を防ぐ。

--- a/doc/modals/gacha_delete_modal_spec.md
+++ b/doc/modals/gacha_delete_modal_spec.md
@@ -1,0 +1,47 @@
+# ガチャ削除確認モーダル (GachaDeleteConfirmDialog) 仕様書
+
+## 1. 概要
+- 選択中のガチャを完全に削除する前にユーザーへ確認を求めるモーダル。ユーザー集計や画像・リアグ情報も削除されることを通知する。【F:index.html†L439-L448】【F:index.html†L1188-L1256】
+
+## 2. 現行実装
+### 2.1 DOM
+- `#deleteModal` はタイトル、対象タグ `#delTarget`、説明文、キャンセル/削除ボタンで構成される。【F:index.html†L439-L448】
+
+### 2.2 スクリプト
+- `openDeleteConfirm(gachaId)` が `pendingDeleteGacha` を設定し、表示名を取得してタグへ表示した後 `open(deleteModal)` を呼び出す。【F:index.html†L1198-L1214】
+- `#delCancel` は `pendingDeleteGacha` をクリアしてモーダルを閉じる。【F:index.html†L1216-L1217】
+- `#delConfirm` は AppState からガチャ削除、画像/リアグ/レアリティの掃除、再描画を行う。【F:index.html†L1219-L1256】
+
+## 3. React 移行後仕様
+### 3.1 コンポーネント API
+```ts
+interface GachaDeleteConfirmDialogProps {
+  gachaId: string;
+  gachaName: string;
+  onConfirm(gachaId: string): Promise<void> | void;
+  onDismiss(): void;
+}
+```
+- `useGachaDeletion(gachaId)` Hook が表示名・関連リソース数・進行状態を返す。
+
+### 3.2 UI
+- 説明文に削除影響（ユーザー集計・画像・リアグ・レアリティ）を箇条書きで表示。
+- ボタンレイアウトは `flex justify-end gap-3` で `キャンセル`（Ghost）と `削除`（Danger）。
+- 削除時にスピナーを表示し、完了までボタンを無効化する。
+
+### 3.3 挙動
+- `onConfirm` 実行時に `gachaService.delete(gachaId)` を呼び、以下の処理をまとめる:
+  1. AppState のガチャデータ、ユーザー履歴、カタログを削除。【F:index.html†L1224-L1231】
+  2. 画像サービスで該当キーの Blob を削除し、リアグサービス・レアリティサービスを同期。【F:index.html†L1233-L1247】
+  3. UI の再描画 (`renderTabs`, `renderItemGrid`, `renderUsersList`, `renderRiaguPanel`) をトリガする。【F:index.html†L1249-L1256】
+- 成功後は `ModalProvider.pop()` を呼び、`useToast` で完了通知を表示。
+
+## 4. サービス/メソッド要件
+- `gachaService.delete(gachaId)`：AppState, counts, catalogs の削除を担うメソッド。
+- `imageService.clearByPrefix`, `riaguService.pruneByCatalog`, `rarityService.deleteGacha` をラップしてまとめて実行する関数。
+- `useModal` から `dismissAll()` を呼び、ガチャ削除時に関連モーダル（景品設定など）が開いていたら閉じる。
+
+## 5. テスト観点
+- 削除確認ダイアログが正しいガチャ名を表示するかスナップショットを作成。
+- `onConfirm` がエラーを返した場合でもモーダルが閉じず、エラーメッセージを表示すること。
+- 成功後に `renderTabs` 等が呼ばれ、UI から対象ガチャが消えることを E2E で確認。

--- a/doc/modals/guide_modal_spec.md
+++ b/doc/modals/guide_modal_spec.md
@@ -1,0 +1,44 @@
+# Guide Modal (GuideInfoDialog) 仕様書
+
+## 1. 概要
+- カタログ貼り付け完了後にリアルタイム入力導線を案内するインフォメーションモーダル。
+- React 版では `GuideInfoDialog` として `StartWizardDialog` から遷移、またはライブ貼り付け完了時のトースト代わりに表示する。
+
+## 2. 現行実装
+### 2.1 DOM 構造
+- `#guideModal` にタイトル、説明文、`#guideOk` ボタンのみを持つシンプルなレイアウト。【F:index.html†L346-L357】
+
+### 2.2 関連スクリプト
+- `startDone()` → `open(guideModal)` のフローで表示され、`#guideOk` クリックで `close(guideModal)` を呼ぶ。【F:index.html†L1742-L1748】【F:index.html†L1812-L1823】
+
+### 2.3 状態
+- `guideModal` は `open/close` 共通関数により `modalCount` を更新、スクロールロックと FAB 制御を共有する。【F:index.html†L1727-L1740】
+
+## 3. React 移行後仕様
+- `GuideInfoDialogProps`:
+  ```ts
+  interface GuideInfoDialogProps {
+    onAcknowledge(): void;
+    context?: 'catalog-complete' | 'live-prompt';
+  }
+  ```
+- UI:
+  - `ModalBody` に案内文、`ModalFooter` にプライマリボタンのみ配置。
+  - `context` に応じて文章を切り替え、将来的にリンクを追加できるよう `description` スロットを用意。
+- 動作:
+  - `onAcknowledge` 実行時にモーダルを閉じ、`ModalProvider.pop()` を呼ぶ。
+  - 開始フローでは `replace` で `GuideInfoDialog` を表示して案内を完結する。
+
+## 4. 状態遷移
+1. カタログ解析完了時またはユーザーがガイドをリクエストしたときに `push(GuideInfoDialog)`。
+2. ユーザーが「分かった」を押すと `onAcknowledge` → `pop()`。
+3. `context` が `catalog-complete` の場合、モーダルを閉じた後にリアルタイム入力ボタンへフォーカスを移動させる。
+
+## 5. 必要なメソッド
+- `useGuidePrompt()` Hook: `context` に応じて文章とフォーカス遷移ターゲットを決定。
+- `focusLiveButton()` ユーティリティ：既存の `#openLivePaste` ボタンにフォーカスを移すロジックを React へ移植。【F:index.html†L180-L183】
+
+## 6. テスト観点
+- カタログ完了後に `GuideInfoDialog` が表示され、「分かった」で閉じると `modalCount` が 0 に戻ることを検証。
+- `Escape` キーで閉じても `onAcknowledge` が 1 回だけ呼ばれること。
+- 案内文が `context` に応じて切り替わるスナップショットテストを Storybook で追加する。

--- a/doc/modals/item_delete_modal_spec.md
+++ b/doc/modals/item_delete_modal_spec.md
@@ -1,0 +1,50 @@
+# アイテム削除確認モーダル (ItemDeleteConfirmDialog) 仕様書
+
+## 1. 概要
+- ガチャ内の特定アイテムを削除する際の確認モーダル。ユーザー履歴やカタログからの削除影響を通知する。【F:index.html†L452-L467】【F:index.html†L1258-L1324】
+
+## 2. 現行実装
+### 2.1 DOM
+- `#itemDeleteModal` は対象タグ `#idelTarget`、警告テキスト `#idelWarn`、キャンセル/削除ボタンで構成される。【F:index.html†L452-L467】
+
+### 2.2 スクリプト
+- `openItemDeleteConfirm(it)` が `pendingDeleteItem` を設定し、対象を表示。`countUsersWithItem` で所有ユーザー数を計算し、警告の表示/非表示を制御する。【F:index.html†L1266-L1283】
+- `#idelCancel` は `pendingDeleteItem` をクリアし、モーダルを閉じる。【F:index.html†L1285-L1288】
+- `#idelConfirm` は対象アイテムをカタログ・ユーザー履歴・獲得数から削除し、再描画と保存を行う。【F:index.html†L1290-L1338】
+
+## 3. React 移行後仕様
+### 3.1 コンポーネント API
+```ts
+interface ItemDeleteConfirmDialogProps {
+  gachaId: string;
+  rarityId: string;
+  itemCode: string;
+  affectedUsers: number;
+  onConfirm(payload: { gachaId: string; rarityId: string; itemCode: string }): Promise<void> | void;
+  onDismiss(): void;
+}
+```
+- `useItemDeletion(it)` Hook が `affectedUsers`, `isDeleting`, `error` を返す。
+
+### 3.2 UI
+- 警告メッセージを `Alert` コンポーネントとして表示し、`affectedUsers > 0` の場合は強調色（`bg-error/10`）。
+- ボタンレイアウトは `flex justify-end gap-3`、削除ボタンは Danger。
+- ローディング中は削除ボタンにスピナーを表示し、複数クリックを防止する。
+
+### 3.3 挙動
+- `onConfirm` は以下の処理をまとめて行う:
+  1. `imageService.clear` と `skipDel` 相当の処理で関連画像/リアグ状態をクリア。【F:index.html†L1302-L1314】
+  2. `catalogService.removeItem` でカタログから該当アイテムを削除。【F:index.html†L1296-L1300】
+  3. `userHistoryService.removeItem` で全ユーザーの履歴と獲得数から削除。【F:index.html†L1302-L1334】
+  4. AppState を保存 (`saveAppStateDebounced`) し、UI を再描画。【F:index.html†L1335-L1338】
+- 成功後に `ModalProvider.pop()`、`useToast` で削除完了通知。
+
+## 4. サービス/メソッド要件
+- `itemService.deleteItem(it)`：カタログ・履歴・画像をまとめて削除するサービス層 API。
+- `userHistoryService.countUsersWithItem`：事前に影響ユーザー数を算出するユーティリティ。
+- `useModal` から `pop()` を呼び、削除後に親モーダルや呼び出し元カードへフォーカスを返す。
+
+## 5. テスト観点
+- `affectedUsers` が 0 の場合に警告が非表示になること。
+- `onConfirm` の副作用（画像クリア・ユーザーデータ更新・保存）が順番どおり呼ばれることをユニットテスト。
+- キャンセル時に `pendingDeleteItem` がクリアされることを確認。

--- a/doc/modals/live_paste_modal_spec.md
+++ b/doc/modals/live_paste_modal_spec.md
@@ -1,0 +1,49 @@
+# Live Paste Modal (LivePasteDialog) 仕様書
+
+## 1. 概要
+- リアルタイム配信などで取得した結果テキストを貼り付け、ユーザー集計へ反映するモーダル。
+- React 版では `LivePasteDialog` として `textarea`・反映ボタン・閉じるボタンを持ち、入力解析結果をストアへディスパッチする。
+
+## 2. 現行実装
+### 2.1 DOM 構造
+- `#liveModal` には説明テキスト、`#liveText` テキストエリア、`#liveApply`（反映）・`#liveClose`（閉じる）ボタンを配置。【F:index.html†L360-L371】
+
+### 2.2 関連スクリプト
+- `#openLivePaste` ボタンから `open(liveModal)`、`#liveClose` で `close(liveModal)` を呼ぶ。【F:index.html†L1755-L1757】
+- `#liveApply` クリック時に入力を `splitLiveBlocks` → `parseLiveBlock` で解析し、ユーザーごとの `delta` を構築後 `mergeIntoGData` 等を呼び出す。【F:index.html†L1824-L1876】
+- 貼り付け成功後は `close(liveModal)`→`startDone()`→各 UI 再描画関数を実行する。【F:index.html†L1877-L1893】
+
+### 2.3 状態・入出力
+- 入力テキストは `textarea` の値を直接取得し、解析結果から `gData`, `gHitCounts`, `gCatalogByGacha` を更新する。【F:index.html†L1850-L1874】
+- 解析失敗時は `alert` でエラーメッセージを表示し、モーダルは開いたまま。
+
+## 3. React 移行後仕様
+- `LivePasteDialogProps`:
+  ```ts
+  interface LivePasteDialogProps {
+    defaultText?: string;
+    onSubmit(blocks: string): Promise<void> | void;
+    onDismiss(): void;
+  }
+  ```
+- UI:
+  - `Textarea` コンポーネント（`autosize` オプション付き）を使用し、`min-h-[220px]` とモノスペースフォントを適用。
+  - エラー表示は `Alert` コンポーネントで `parseLiveInput` の結果を表示。
+- 動作:
+  - `onSubmit` は `parseLiveBlocks` Hook を経由し、React ストアの `importLiveResult(delta)` を呼ぶ。
+  - 成功時は `ModalProvider.pop()`、失敗時はエラーをステートに保持して入力は保持する。
+
+## 4. 状態遷移
+1. `useModal().push(LivePasteDialog)` で表示。
+2. ユーザーがテキストを入力して「反映」を押す → バリデーション。空なら警告。
+3. 解析成功で `onSubmit` が `appState.applyLiveDelta(delta)` を実行し、`useToast` で完了通知を表示。
+4. モーダルを閉じるときに `onDismiss` → `ModalProvider.pop()`、必要なら `confirm` で未保存テキスト破棄確認を出す。
+
+## 5. 必要なモジュール
+- `useLiveParser()` Hook：`splitLiveBlocks`, `parseLiveBlock`, `mergeIntoGacha` を React 化し、成功時の副作用をまとめる。【F:index.html†L1824-L1893】
+- `appState.mergeLiveDelta(delta)`：既存の `mergeIntoGData`, `incCount` などをサービス層に再配置。
+
+## 6. テスト観点
+- 空テキストで警告が出て `onSubmit` が呼ばれないこと。
+- 正常入力時に `appState.mergeLiveDelta` が期待どおり呼ばれ、`ModalProvider` のスタックが 1 減ること。
+- 長文貼り付け時のパフォーマンスとスクロール挙動を Storybook で検証する。

--- a/doc/modals/prize_settings_modal_spec.md
+++ b/doc/modals/prize_settings_modal_spec.md
@@ -20,16 +20,22 @@
 ### 3.1 コンポーネント API
 ```ts
 interface PrizeSettingsDialogProps {
-  gachaId: string;
+  itemId: ItemId; // 10 桁不変 ID
+  initial: PrizeSettingsInitialState;
+  onSave(itemId: ItemId, input: PrizeSettingsInput): Promise<void> | void;
+  onOpenRiagu(itemId: ItemId): void;
+  onRequestClose(): void;
+}
+
+interface PrizeSettingsInitialState {
+  name: string;
   rarityId: string;
-  itemCode: string;
-  initialName: string;
-  initialPreviewUrl?: string;
-  initialPickup: boolean;
-  initialCompleteTarget: boolean;
-  onSave(input: PrizeSettingsInput): Promise<void> | void;
-  onOpenRiagu(): void;
-  onDismiss(): void;
+  gachaId: string;
+  gachaDisplayName: string;
+  itemKey: string; // 旧 UI 互換キー（gachaId::rarityId::itemCode）
+  previewUrl?: string;
+  pickup: boolean;
+  completeTarget: boolean;
 }
 
 interface PrizeSettingsInput {
@@ -40,24 +46,27 @@ interface PrizeSettingsInput {
   completeTarget: boolean;
 }
 ```
-- `usePrizeSettings(gachaId, rarityId, itemCode)` Hook でフォーム状態とプレビュー URL、既存タグ状態を提供する。【F:doc/modal_component_plan.md†L87-L91】
+- Props の `itemId` は CatalogStore の `ItemCardModel.itemId` に一致し、React 側での唯一キーとして利用する。【F:doc/item_component_plan.md†L14-L43】
+- `itemKey` はレガシー互換用途のみ。保存時に必要であれば `legacyItemCodeIndex` を更新するため `usePrizeSettings` 内で参照する。【F:doc/react_migration_plan.md†L54-L90】
+- `usePrizeSettings(itemId)` Hook でフォーム状態とプレビュー URL、タグ状態、レガシー `itemKey` 変換ユーティリティを提供する。【F:doc/modal_component_plan.md†L87-L91】
 
 ### 3.2 UI レイアウト
-- ヘッダー: タイトル「景品設定」と対象タグ (`Badge` で `gachaName / rarity:code`) を表示。
+- ヘッダー: タイトル「景品設定」と対象タグ (`Badge` で `gachaDisplayName / rarityId`) を表示し、サブテキストで `itemKey` を確認できるようにする。
 - ボディ: `grid gap-6 lg:grid-cols-[minmax(0,1fr),minmax(0,1fr)]` で左にプレビュー、右にファイル/操作ボックスを配置。【F:doc/modal_component_plan.md†L88-L90】
-  - 左: `AspectRatio` コンポーネントでサムネイル表示、下に状態ラベルと「現在の画像」情報。
-  - 右: `FileDropZone` + `Button` でファイル選択、`Switch` コンポーネントで「ピックアップ対象」「コンプリートガチャ対象」を並べる。URL 入力は廃止する。【F:doc/modal_component_plan.md†L90-L91】
-  - `OpenRiaguDialogButton` を右列のアクション群に配置し、クリックでリアグ設定モーダルを開く。
-- フッター: `保存`, `リアグ設定を開く`, `閉じる` の 3 ボタンを `flex justify-between` で配置し、閉じるボタンで未保存確認ダイアログを表示する。【F:doc/modal_component_plan.md†L91-L91】
+  - 左: `AspectRatio` コンポーネントでサムネイル表示、下に状態ラベルと `imageAsset.hasImage` に応じたステータスメッセージを表示。
+  - 右: `TextField` (景品名), `RaritySelect` (レアリティ), `FileDropZone` + `Button` でファイル選択、`Switch` コンポーネントで「ピックアップ対象」「コンプリートガチャ対象」を並べる。URL 入力は廃止する。【F:doc/modal_component_plan.md†L90-L91】
+  - `OpenRiaguDialogButton` を右列のアクション群に配置し、クリックでリアグ設定モーダルを開く。リアグ遷移時も `itemId` を引き渡す。
+- フッター: 左に `リアグ設定を開く`（セカンダリボタン）、右に `閉じる`（トーナリー）と `保存`（プライマリ）を `flex justify-between lg:justify-end lg:gap-3` で配置。閉じるボタンで未保存確認ダイアログを表示する。【F:doc/modal_component_plan.md†L91-L91】
 
 ### 3.3 振る舞い
 - 保存実行時:
-  1. 名前・レアリティの変更を `appState.renameItemCode` / `appState.moveItemRarity` 相当のサービスで処理する。【F:index.html†L1435-L1496】
-  2. 画像ファイルがあれば `imageService.putBlob` へアップロードし、なければ既存プレビューを維持。
-  3. トグル状態を `itemTagService.setPickup/clearPickup`, `itemTagService.setComplete` など新設メソッドで保存する。
-  4. `onSave` 完了後に関連ストア (`ImageAssetStore`, `PrizeTagStore`) を更新し、`ModalProvider.pop()` でモーダルを閉じる。
+  1. CatalogStore の `updateItemCard(itemId, patch)` で `name`・`rarityId`・`pickupTarget`・`completeTarget` を更新。レアリティ変更時は `CatalogStore.moveItemToRarity(itemId, rarityId)` を併用する。【F:doc/item_component_plan.md†L29-L39】
+  2. 画像ファイルがあれば `imageService.putBlob(itemId, file)` へアップロードし、結果の `assetHash`・`thumbnailUrl` を `updateItemAsset(itemId, patch)` で反映する。【F:index.html†L1435-L1496】【F:doc/item_component_plan.md†L33-L36】
+  3. トグル状態を `CatalogStore.togglePickupTarget` / `toggleCompleteTarget` 相当のアクションで保存し、必要に応じて `prizeTagService` へ永続化する。
+  4. 旧 UI 互換のため `legacyItemCodeIndex` を持つガチャには `itemKey` と `itemId` を同期させる。`usePrizeSettings` が `ensureLegacyItemKey(itemId, itemKey)` を呼び出す。
+  5. `onSave(itemId, input)` を await し、成功後に `ModalProvider.pop()` でモーダルを閉じる。エラー発生時は `state.error` に格納してフッターにアラートを表示。
 - 閉じる操作: 変更が検知された場合は `ConfirmDiscardDialog` を `ModalProvider.push` で表示し、「景品設定に戻る」「閉じる」選択肢を提示する。【F:doc/modal_component_plan.md†L91-L91】
-- リアグボタン: `onOpenRiagu` で `RiaguConfigDialog` を別モーダルとして開き、閉じた後も景品設定モーダルはスタックに残す。
+- リアグボタン: `onOpenRiagu(itemId)` で `RiaguConfigDialog` を別モーダルとして開き、閉じた後も `PrizeSettingsDialog` の状態が維持されるよう `ModalStack` を利用する。
 
 ## 4. 状態管理
 - `PrizeSettingsState`:
@@ -69,22 +78,26 @@ interface PrizeSettingsInput {
     completeTarget: boolean;
     file?: File;
     previewUrl?: string;
+    itemKey: string;
     isDirty: boolean;
     isSaving: boolean;
     error?: string;
   }
   ```
-- `usePrizeSettings` は `useReducer` で `SET_FIELD`, `SET_FILE`, `RESET`, `SET_ERROR` を扱い、`useEffect` で `file` を開放（`URL.revokeObjectURL`）。
-- ピックアップ/コンプリート情報は `itemMetaService.getTags(key)` から取得し、`onSave` で更新する。
+- `usePrizeSettings(itemId)` は `useReducer` で `SET_FIELD`, `SET_FILE`, `RESET`, `SET_ERROR`, `SET_PREVIEW` を扱い、`useEffect` で `file` の `ObjectURL` を開放する。初期化時に CatalogStore から `ItemCardModel` を取得し、`itemId` の更新イベントを購読する。
+- ピックアップ/コンプリート情報は CatalogStore からの selector (`useItemFlags(itemId)`) を合成し、トグル時に `dispatch({ type: 'SET_FIELD', ... })` でローカル状態を更新。
+- レガシー互換: `itemKey` が変更された場合でも `itemId` を正とする。互換 API 呼び出しが必要な場合は `useLegacyItemKey(itemId)` Hook で `itemKey` を取得・同期する。
 
 ## 5. サービス/メソッド要件
-- `imageService`：既存の `putBlob`, `renameKey`, `clear` を Promise ベースで提供する。【F:index.html†L1435-L1496】
-- `appState`：`renameItemCode`, `moveItemRarity`, `saveDebounced` を React ストアへ移行する。【F:index.html†L1435-L1512】
-- `prizeTagService`（新規）：ピックアップ/コンプリート種別を永続化する API (`get`, `set`, `clear`) を提供。
+- `CatalogStore`：`updateItemCard`, `moveItemToRarity`, `togglePickupTarget`, `toggleCompleteTarget`, `updateItemAsset` を Promise ベースで提供し、`itemId` を唯一キーにする。【F:doc/item_component_plan.md†L24-L39】
+- `imageService`：既存の `putBlob`, `renameKey`, `clear` を `itemId` 受け取りの API へ更新する。旧 `itemCode` からの変換はドメイン層で吸収する。【F:index.html†L1435-L1496】
+- `prizeTagService`（新規）：ピックアップ/コンプリート種別を `itemId` で永続化する API (`get`, `set`, `clear`) を提供し、旧 `itemCode` ベースのデータはマイグレーションで移行する。
 - `useConfirmDiscard` Hook：変更検知時の破棄確認モーダルを開くユーティリティ。
+- `ensureLegacyItemKey(itemId, itemKey)`：`CatalogStore` の `legacyItemCodeIndex` を更新し、TXT/JSON エクスポート時に旧クライアントへ互換データを提供する。【F:doc/react_migration_plan.md†L63-L90】
 
 ## 6. テスト観点
 - 変更がない状態で閉じると確認ダイアログが表示されないこと、変更後はダイアログが表示されること。
-- `onSave` が名前変更→レアリティ移動→画像保存→タグ保存の順で呼ばれることをモックで検証。
+- `onSave` が `updateItemCard` → `moveItemToRarity`（必要時）→ `imageService.putBlob` → `prizeTagService.set` の順で呼ばれることをモックで検証。
+- `itemId` を変更せずに `itemKey` のみが変化した場合でも legacy インデックスが同期されること。
 - ファイル選択後に別ファイルへ差し替えた場合、古い `ObjectURL` が破棄されること。
 - リアグボタン押下で `RiaguConfigDialog` が開き、戻った後に `PrizeSettingsDialog` の状態が維持されること。

--- a/doc/modals/prize_settings_modal_spec.md
+++ b/doc/modals/prize_settings_modal_spec.md
@@ -1,0 +1,90 @@
+# 景品設定モーダル (PrizeSettingsDialog) 仕様書
+
+## 1. 概要
+- 旧「画像を設定」モーダルをリネームし、景品名・レアリティ・プレビュー・ファイル選択・運用タグ（ピックアップ/コンプリート対象）を一括管理するモーダル。
+- ItemCard から呼び出され、リアグ設定モーダルへの遷移ボタンも内包する。【F:index.html†L374-L415】【F:index.html†L880-L918】
+
+## 2. 現行実装の構造
+### 2.1 DOM
+- `#imageModal` には対象入力、レアリティセレクト、プレビュー枠、ファイル選択、URL 入力、保存/閉じるボタンが存在する。【F:index.html†L374-L411】
+- プレビューは `#modalPreview`, 状態ラベルは `#modalStatus`、保存ボタンは `#applyBtn`、閉じるボタンは `#closeBtn` で定義されている。【F:index.html†L390-L411】
+
+### 2.2 関連スクリプト
+- `openImageModal(it)` が現在のアイテム情報を読み込み、プレビューとフォームを初期化する。【F:index.html†L1341-L1408】
+- `#fileInput` / `#urlInput` の変更でプレビューを更新し、`#applyBtn` が `images.putBlob` などの保存処理を行う。【F:index.html†L1411-L1563】
+- 保存後に `renderItemGrid`, `renderUsersList`, `renderRiaguPanel` を再描画し、`closeImageModal()` がモーダルを閉じる。【F:index.html†L1507-L1563】
+- ItemCard の「画像設定」ボタンから呼び出され、`hasImage` に応じて解除/設定を切り替える。【F:index.html†L883-L913】
+- 現状はリアグ設定ボタンが ItemCard 側にあり、モーダル内には存在しない。【F:index.html†L889-L917】
+
+## 3. React 移行後仕様
+### 3.1 コンポーネント API
+```ts
+interface PrizeSettingsDialogProps {
+  gachaId: string;
+  rarityId: string;
+  itemCode: string;
+  initialName: string;
+  initialPreviewUrl?: string;
+  initialPickup: boolean;
+  initialCompleteTarget: boolean;
+  onSave(input: PrizeSettingsInput): Promise<void> | void;
+  onOpenRiagu(): void;
+  onDismiss(): void;
+}
+
+interface PrizeSettingsInput {
+  name: string;
+  rarityId: string;
+  file?: File;
+  pickup: boolean;
+  completeTarget: boolean;
+}
+```
+- `usePrizeSettings(gachaId, rarityId, itemCode)` Hook でフォーム状態とプレビュー URL、既存タグ状態を提供する。【F:doc/modal_component_plan.md†L87-L91】
+
+### 3.2 UI レイアウト
+- ヘッダー: タイトル「景品設定」と対象タグ (`Badge` で `gachaName / rarity:code`) を表示。
+- ボディ: `grid gap-6 lg:grid-cols-[minmax(0,1fr),minmax(0,1fr)]` で左にプレビュー、右にファイル/操作ボックスを配置。【F:doc/modal_component_plan.md†L88-L90】
+  - 左: `AspectRatio` コンポーネントでサムネイル表示、下に状態ラベルと「現在の画像」情報。
+  - 右: `FileDropZone` + `Button` でファイル選択、`Switch` コンポーネントで「ピックアップ対象」「コンプリートガチャ対象」を並べる。URL 入力は廃止する。【F:doc/modal_component_plan.md†L90-L91】
+  - `OpenRiaguDialogButton` を右列のアクション群に配置し、クリックでリアグ設定モーダルを開く。
+- フッター: `保存`, `リアグ設定を開く`, `閉じる` の 3 ボタンを `flex justify-between` で配置し、閉じるボタンで未保存確認ダイアログを表示する。【F:doc/modal_component_plan.md†L91-L91】
+
+### 3.3 振る舞い
+- 保存実行時:
+  1. 名前・レアリティの変更を `appState.renameItemCode` / `appState.moveItemRarity` 相当のサービスで処理する。【F:index.html†L1435-L1496】
+  2. 画像ファイルがあれば `imageService.putBlob` へアップロードし、なければ既存プレビューを維持。
+  3. トグル状態を `itemTagService.setPickup/clearPickup`, `itemTagService.setComplete` など新設メソッドで保存する。
+  4. `onSave` 完了後に関連ストア (`ImageAssetStore`, `PrizeTagStore`) を更新し、`ModalProvider.pop()` でモーダルを閉じる。
+- 閉じる操作: 変更が検知された場合は `ConfirmDiscardDialog` を `ModalProvider.push` で表示し、「景品設定に戻る」「閉じる」選択肢を提示する。【F:doc/modal_component_plan.md†L91-L91】
+- リアグボタン: `onOpenRiagu` で `RiaguConfigDialog` を別モーダルとして開き、閉じた後も景品設定モーダルはスタックに残す。
+
+## 4. 状態管理
+- `PrizeSettingsState`:
+  ```ts
+  interface PrizeSettingsState {
+    name: string;
+    rarityId: string;
+    pickup: boolean;
+    completeTarget: boolean;
+    file?: File;
+    previewUrl?: string;
+    isDirty: boolean;
+    isSaving: boolean;
+    error?: string;
+  }
+  ```
+- `usePrizeSettings` は `useReducer` で `SET_FIELD`, `SET_FILE`, `RESET`, `SET_ERROR` を扱い、`useEffect` で `file` を開放（`URL.revokeObjectURL`）。
+- ピックアップ/コンプリート情報は `itemMetaService.getTags(key)` から取得し、`onSave` で更新する。
+
+## 5. サービス/メソッド要件
+- `imageService`：既存の `putBlob`, `renameKey`, `clear` を Promise ベースで提供する。【F:index.html†L1435-L1496】
+- `appState`：`renameItemCode`, `moveItemRarity`, `saveDebounced` を React ストアへ移行する。【F:index.html†L1435-L1512】
+- `prizeTagService`（新規）：ピックアップ/コンプリート種別を永続化する API (`get`, `set`, `clear`) を提供。
+- `useConfirmDiscard` Hook：変更検知時の破棄確認モーダルを開くユーティリティ。
+
+## 6. テスト観点
+- 変更がない状態で閉じると確認ダイアログが表示されないこと、変更後はダイアログが表示されること。
+- `onSave` が名前変更→レアリティ移動→画像保存→タグ保存の順で呼ばれることをモックで検証。
+- ファイル選択後に別ファイルへ差し替えた場合、古い `ObjectURL` が破棄されること。
+- リアグボタン押下で `RiaguConfigDialog` が開き、戻った後に `PrizeSettingsDialog` の状態が維持されること。

--- a/doc/modals/riagu_modal_spec.md
+++ b/doc/modals/riagu_modal_spec.md
@@ -1,0 +1,65 @@
+# リアグ設定モーダル (RiaguConfigDialog) 仕様書
+
+## 1. 概要
+- 景品ごとのリアルグッズ情報（原価・タイプ）を設定し、リアグ対象フラグを付与するモーダル。
+- React 版では景品設定モーダルから遷移するサブモーダルとして動作し、リアグ解除を含むメタ管理を提供する。【F:index.html†L417-L435】【F:src/ui-riagu.js†L268-L336】
+
+## 2. 現行実装
+### 2.1 DOM
+- `#riaguModal` はタイトル、対象表示タグ `#riaguTarget`、原価入力 `#riaguCost`、タイプ入力 `#riaguType`、保存/解除/閉じるボタンで構成される。【F:index.html†L417-L435】
+
+### 2.2 スクリプト
+- `openRiaguModal(it)` が対象の gachaId/rarity/code を正規化し、リアグメタを取得してフォームへ代入、`getModalOpen()` でモーダルを開く。【F:src/ui-riagu.js†L268-L311】
+- `closeRiaguModal()` は `getModalClose()` を通じて閉じ、`currentRiaguTarget` を破棄する。【F:src/ui-riagu.js†L313-L318】
+- `#riaguSave` はリアグメタを保存し、画像解除→リアグマーク→描画更新を行う。【F:src/ui-riagu.js†L322-L360】
+- `#riaguUnset` はリアグメタを削除し、描画を更新する。【F:src/ui-riagu.js†L210-L240】
+- ItemCard の「リアグ」ボタンからモーダルを開くよう結線されている。【F:index.html†L883-L918】
+
+## 3. React 移行後仕様
+### 3.1 コンポーネント API
+```ts
+interface RiaguConfigDialogProps {
+  gachaId: string;
+  rarityId: string;
+  itemCode: string;
+  defaultCost?: number;
+  defaultType?: string;
+  onSave(input: { cost: number; type: string }): Promise<void> | void;
+  onUnset(): Promise<void> | void;
+  onDismiss(): void;
+}
+```
+- `useRiaguConfig(gachaId, rarityId, itemCode)` Hook が `cost`, `type`, `isSaving`, `error` を返し、`submit`/`unset` メソッドを提供する。
+
+### 3.2 UI
+- Tailwind `max-w-lg` のモーダルパネルを使用し、フォームは `space-y-4` で配置。
+- 原価入力は `NumberField` コンポーネントで千区切り表示、タイプ入力は `TextField`。
+- フッターは `保存`（Primary）、`リアグ解除`（Ghost Danger）、`閉じる`（Ghost）ボタンを `flex justify-end gap-3` で配置。【F:index.html†L431-L435】
+
+### 3.3 挙動
+- `onSave` は `riaguService.mark({ gachaId, rarityId, itemCode }, { cost, type })` を呼び、成功後に `ModalProvider.pop()`。
+- `onUnset` は `riaguService.unmark` と `imageService.tryRemoveSkip` を呼び、景品設定モーダルへ制御を戻す。
+- 閉じる操作は単に `pop()` し、必要に応じて親モーダルへフォーカスを戻すため `onDismiss` で `focusReturnRef` を使用する。
+
+## 4. 状態管理
+- `RiaguConfigState`:
+  ```ts
+  interface RiaguConfigState {
+    cost: string;
+    type: string;
+    isSaving: boolean;
+    error?: string;
+  }
+  ```
+- コストはフォーム上では文字列で保持し、送信時に数値へ変換（`Math.max(0, parseInt(...))`）。【F:src/ui-riagu.js†L335-L356】
+- リアグ解除時は `itemTagService` からリアグ関連タグを削除し、`PrizeSettingsDialog` 側の状態も同期させる。
+
+## 5. サービス/メソッド要件
+- `riaguService`：`mark`, `unmark`, `getMeta`, `pruneByCatalog` を Promise ベースで提供。【F:src/ui-riagu.js†L268-L360】
+- `imageService`：リアグ解除時に画像 skip を外す `clearImage` 相当のメソッドを公開する。【F:index.html†L1509-L1524】
+- `useModalStack`：サブモーダルから親モーダルへフォーカスを戻す `returnFocus()` をサポート。
+
+## 6. テスト観点
+- 保存時に `riaguService.mark` が正しい payload で呼ばれること、数値変換が行われることをユニットテストする。
+- 解除ボタン押下で `riaguService.unmark` → `renderItemGrid` 相当の更新が走ることをモックで検証。
+- 親モーダル（景品設定）が開いたままでもフォーカストラップが二重にならないことを Cypress/Playwright で確認。

--- a/doc/modals/save_options_modal_spec.md
+++ b/doc/modals/save_options_modal_spec.md
@@ -1,0 +1,54 @@
+# 保存オプションモーダル (SaveOptionsDialog) 仕様書
+
+## 1. 概要
+- ユーザーごとのデータをエクスポートする手段（ローカル保存、shimmy3.com アップロード、Discord 直接送信）を提供するモーダル。【F:index.html†L474-L517】【F:src/blob-upload.js†L1-L209】
+
+## 2. 現行実装
+### 2.1 DOM
+- `#saveOptionModal` には 2 枚のカード（ローカル保存、shimmy3.com アップロード）とアップロード結果表示、閉じるボタンがある。【F:index.html†L479-L515】
+
+### 2.2 スクリプト
+- `initSaveModal()` がイベントをバインドし、ローカル保存 (`#saveDeviceBtn`)、アップロード (`#uploadBlobBtn`)、結果コピー (`#copyUploadUrlBtn`) を処理する。【F:src/blob-upload.js†L99-L209】
+- アップロード時は ZIP を生成 → Vercel Blob へアップロード → 受け取り URL を取得 → UI 更新 → `setLastUploadUrl` を呼び出す。【F:src/blob-upload.js†L144-L188】【F:index.html†L1001-L1033】
+
+## 3. React 移行後仕様
+### 3.1 コンポーネント API
+```ts
+interface SaveOptionsDialogProps {
+  targetUser: string;
+  gachaSnapshot: UserGachaSnapshot;
+  lastShareUrl?: string;
+  onClose(): void;
+}
+```
+- `useSaveOptions(user)` Hook が ZIP 生成、アップロード、Discord 送信ロジックをまとめて提供する。
+
+### 3.2 UI
+- 3 カード構成 (`grid sm:grid-cols-3 gap-4`) とし、各カードにタイトル・説明・CTA ボタンを配置。【F:doc/modal_component_plan.md†L99-L100】
+  1. **自分で保存して共有する**：ローカル ZIP 保存。既存機能を踏襲。
+  2. **shimmy3.com のアップロード（無料）**：既存説明。
+  3. **自分のDiscordサーバーに直接送信**：説明文に「これは shimmy3.com に ZIP ファイルをアップロードしたうえで、そのリンクを自動でリスナーに渡します。」と明記する。
+- アップロード結果セクションは共通でリンク/コピー UI を表示。Discord 送信時も同じ結果ボックスを再利用する。【F:doc/modal_component_plan.md†L100-L101】
+- 閉じるボタンは `ModalFooter` の右端に配置。
+
+### 3.3 挙動
+- ローカル保存: 既存の ZIP 生成 → 保存処理を `useSaveOptions().saveToDevice()` に移植。【F:src/blob-upload.js†L118-L143】
+- shimmy3.com アップロード: 既存処理を `useSaveOptions().uploadToShimmy()` として再実装し、完了後に結果ボックスを表示する。【F:src/blob-upload.js†L144-L188】
+- Discord 直接送信:
+  1. `uploadToShimmy()` と同様に ZIP を生成し shimmy3.com へアップロード。
+  2. 受け取った共有 URL を Discord Webhook/リスナー API に送信する（`discordService.sendShareLink({ user, shareUrl })`）。
+  3. 成功時に結果ボックスへ共有 URL を表示し、「Discord へ送信済み」とメッセージを表示。
+  4. 失敗時はエラー表示し、再送ボタンを有効化。
+- モーダルを開いた際に `lastShareUrl` があれば `コピー` ボタンを表示する（従来どおり）。【F:index.html†L1008-L1017】
+
+## 4. サービス/メソッド要件
+- `zipService.buildForUser(user, snapshot)`：ZIP 生成を Promise で返す既存ロジックの抽象化。【F:src/blob-upload.js†L118-L134】
+- `shimmyUploadService.upload(blob)`：`uploadZip` + `issueReceiveShareUrl` をまとめるサービス。
+- `discordService.sendShareLink`：アップロード結果 URL を Discord Bot/Listener へ送信する新規メソッド。Webhook URL は設定から取得。
+- `saveHistoryService.setLastUploadUrl(user, url)`：結果を永続化し、ユーザー一覧の「URLをコピー」ボタンを更新。【F:index.html†L1001-L1033】
+
+## 5. テスト観点
+- 3 カードが正しく表示され、各ボタンが固有のハンドラを呼ぶことをユニットテスト。
+- Discord 送信が失敗した場合にエラーが表示され、結果 URL は保持されること。
+- 既存の「URLをコピー」ボタンが Discord 経由の共有でも利用できること。
+- `initSaveModal` 互換 API が引き続き動作し、非 React コードからもモーダルが開けることを回帰テスト。

--- a/doc/modals/start_modal_spec.md
+++ b/doc/modals/start_modal_spec.md
@@ -1,0 +1,51 @@
+# Start Modal (StartWizardDialog) 仕様書
+
+## 1. 概要
+- 起動時にユーザーへ初期フロー（外部TXT取込・JSON読込・新規作成）を提示するオンボーディングモーダル。
+- React 移行後は `StartWizardDialog` として `ModalProvider` 配下から呼び出し、Tailwind のカードグリッドで 3 タイルを表示する。
+
+## 2. 現行実装の構造
+### 2.1 DOM 構造
+- `#startModal` 内に 3 つの `.start-tile` ボタンと JSON/TXT の隠しファイル入力、閉じるボタンを配置。【F:index.html†L291-L324】
+
+### 2.2 関連スクリプト
+- `#openStart` クリックで `open(startModal)` を実行し、`#closeStart` で `close(startModal)` を呼び出す。【F:index.html†L1751-L1757】
+- `startDone()` はスプラッシュ画面の非表示とメイン UI の表示を制御し、開始モーダルを閉じる。【F:index.html†L1742-L1748】
+- 各タイルのクリックハンドラは別スクリプト（`src/ui-start.js` 相当の既存実装）でファイル選択や新規作成フローへ分岐する想定。（`tileTxt`, `tileJson`, `tileNew` の DOM ID）【F:index.html†L297-L314】
+
+### 2.3 状態・入出力
+- グローバル `modalCount` が `open/close` で更新され、`body.modal-open` クラス制御を行う。【F:index.html†L1727-L1740】
+- JSON/TXT のファイル選択結果は `window.handleTxtImport`, `window.handleJsonImport` 等既存関数から取り扱われる（React 移行時に Hook 化する）。
+
+## 3. React 移行後の仕様
+- `StartWizardDialogProps`:
+  ```ts
+  interface StartWizardDialogProps {
+    onSelectTxt(file: File): void;
+    onSelectJson(file: File): void;
+    onCreateNew(): void;
+    onDismiss(): void;
+  }
+  ```
+- UI:
+  - `grid grid-cols-1 sm:grid-cols-3 gap-4` で 3 枚のカードを並べ、カードは `button` + `aria-describedby` で説明文を持つ。
+  - Tailwind の `sr-only` ラベルでファイル入力を隠し、`useHiddenFileInput` Hook で `accept` を制御する。
+- 動作:
+  - `onSelectTxt`/`onSelectJson` は `ModalProvider` 経由で渡すハンドラを通じ、アップロード成功後に `startDone` 相当の状態更新を実行。
+  - `onDismiss` 時は `startDone` を呼ばず単にモーダルを閉じる。
+
+## 4. 状態遷移とイベントフロー
+1. FAB やメニューから `push({ component: StartWizardDialog })` → モーダル開く。
+2. タイル選択時に Hidden File Input を起動し、ファイル確定で `onSelect*` を呼ぶ。
+3. `onSelect*` が完了したら `ModalProvider.pop()` → `StartWizardDialog` が閉じる。
+4. `onCreateNew` は React ストアへ `app.createNewGacha()` を dispatch し、`startDone` 相当の UI 切替を行う。
+
+## 5. 必要な関数・メソッド
+- `useStartWizard()` Hook: TXT/JSON の読み込みロジックとスプラッシュ解除をカプセル化。
+- `appState.createNewGacha()` / `appState.importFromTxt()` / `appState.importFromJson()`：既存グローバル関数を React サービスとして再公開する。
+- `useModal()` から `replace` を使ってガイドモーダルに遷移する補助（TXT 貼り付けを開始する場合）。
+
+## 6. テスト観点
+- TXT/JSON ボタン押下後にファイル選択キャンセルしてもモーダルが閉じないことを確認。
+- スプラッシュロック中 (`body` に `splash-locked`) で `StartWizardDialog` を開き、`onCreateNew` でメイン UI が表示されることを検証。
+- キーボード操作 (Tab/Enter/Escape) によるフォーカス移動と閉じる挙動を React Testing Library + user-event で確認。


### PR DESCRIPTION
## Summary
- update the modal migration plan to drop the catalog paste dialog, rename the prize modal, and add the new Discord save option
- add detailed specifications under doc/modals/ for each active dialog and the legacy catalog modal removal strategy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1568ed9148326bc4baa491dac1972