### PR TITLE
Update riagu sync documentation

### DIFF
--- a/doc/react_migration_plan.md
+++ b/doc/react_migration_plan.md
@@ -131,6 +131,7 @@ export interface ItemCardModel {
 - `AppStateStore`: React Hook (`useAppState`) が CRUD を行う reducer。旧 `AppStateService` の `createGacha` 等を Action 化。
 - `RarityStore`: ガチャごとのレアリティ一覧・順序制御。`ensureDefaultsForGacha` 等を非同期 Action として実装。
 - `UserInventoryStore`: `state.userInventories` を `[userId][gachaId]` で管理し、`syncInventory`・`addItem`・`removeItem`・`bulkReplaceItems`・`purgeItem` などユーザーパネル計画書と同等のアクションを提供。`useUserInventoryWithItems` や達成率セレクタで `ItemId` 参照を再利用する。
+- `UserStore`: `Record<UserId, UserCardModel>` を保持し、`updateUser` で表示名やアバター色を更新する。`UserChip` は `userId` を渡すだけでストアから最新の表示データを引き直し、レアリティ設定の `emitChange()` と同様に購読者へ再描画を伝播させるが、役割はプロファイル辞書の更新に特化する。
 - `AssetStore`: 画像/音声/動画の取得・保存。IndexedDB は `idb-keyval` でラップし、Service Worker との整合性を確保。
 - `RiaguStore`: リアグ対象と当選者計算。`winnersForKey` をメモ化 selector として提供。
 

--- a/doc/riagu_component_plan.md
+++ b/doc/riagu_component_plan.md
@@ -43,6 +43,7 @@ interface RiaguAssignmentModel {
 }
 ```
 - `RiaguAssignmentModel` は `RiaguCardModel` と `UserInventoryStore` の状態から導出し、ストアには保存しない。
+- `UserInventoryStore` は `[userId][gachaId][rarityId][itemId]` のネスト辞書で在庫数を保持し、`RiaguAssignment` は `inventory.byItemId[itemId]` 逆引きのキャッシュを併用して獲得者リストを構築する。
 
 ## 3. ストア設計
 ### 3.1 RiaguStore
@@ -71,6 +72,7 @@ interface RiaguAssignmentModel {
 ### 3.3 監視と同期
 - `ItemCardStore` が `toggleRiagu(itemId)` を発火した際に `RiaguStore` へ通知し、存在しない `RiaguCard` を初期化する。
 - `UserInventoryStore` または `HitCountStore` が更新されたら、`RiaguAssignment` セレクタが再評価され `RiaguCard` が再レンダーする。
+- `UserStore.updateUser` はユーザープロファイル辞書（`Record<UserId, UserCardModel>`）を直接更新するドメインアクションであり、更新後は `UserChip` が参照している `userId` → 表示名/テーマのマッピングが差し替わる。`RarityStore.emitChange()` のような購読者通知とは層が異なるが、両者とも UI 再描画のトリガーになることを想定する。
 - `RarityStore.onChange` を購読して `RiaguBoard` を再レンダー（Tailwind の色が即反映されるようにする）。
 
 ## 4. React コンポーネント設計
@@ -113,8 +115,9 @@ interface RiaguCardProps {
 ## 5. データ同期フロー
 1. Item 編集で名称を変更 → `ItemCardStore.updateItemCard` → 参照している `RiaguCard` が `item.name` を再描画。
 2. UserCard でユーザー名変更 → `UserStore.updateUser` → `UserChip` が再計算され `RiaguCard` の獲得者表示が更新。
-3. 抽選結果のインポートで `HitCountStore` 更新 → `RiaguAssignment` セレクタが `totalCount` を再計算し、発注数と合計金額が自動更新。
-4. レアリティ設定変更 → `RarityStore` の `label`/`color` が更新 → `RiaguCard` のバッジ色が即時変更。
+3. ガチャ結果の追加やリアルタイム入力で `UserInventoryStore.incrementCount` 等が発火 → `[userId][gachaId][rarityId][itemId]` のカウントが更新され、次フレームで `RiaguAssignment` が再評価され `winners` / `totalCount` / `effectiveOrderQty` / `totalCost` が最新化される。
+4. 抽選結果のインポートで `HitCountStore` 更新 → `RiaguAssignment` セレクタが `totalCount` を再計算し、発注数と合計金額が自動更新。
+5. レアリティ設定変更 → `RarityStore` の `label`/`color` が更新 → `RiaguCard` のバッジ色が即時変更。
 
 ## 6. 永続化と移行
 - 旧 `riaguMeta` ローカルストレージを読み込み、`riaguKey` と `ItemCard.itemKey` を突き合わせて `RiaguCardModel` を作成。マッチしないキーはログへ出力し手動対応。

--- a/doc/riagu_react_sync_spec.md
+++ b/doc/riagu_react_sync_spec.md
@@ -1,0 +1,104 @@
+# Riagu React 同期仕様書
+
+## 1. コンテキスト
+- **対象コンポーネント**: `RiaguBoard`, `RiaguCard`, `RiaguModal`, `UserChip`, `RarityBadge`。
+- **関連ストア**: `RiaguStore`, `UserInventoryStore`, `HitCountStore`, `UserStore`, `RarityStore`。
+- **目的**: リアグ対象アイテムの情報（名称・レアリティ・獲得者・原価）を、React コンポーネントとドメインストアの間でリアルタイムに同期させる。
+
+## 2. データ構造
+### 2.1 RiaguStore
+```ts
+interface RiaguState {
+  riaguCards: Record<RiaguId, RiaguCardModel>;
+  indexByItemId: Record<ItemId, RiaguId>;
+}
+```
+- `riaguCards[riaguId]` には原価、リアグ種別、任意の発注数 (`orderHint`) を保持。
+- `indexByItemId[itemId]` で Item → Riagu の逆引きを保証し、ItemCard トグルと同期する。
+
+### 2.2 UserInventoryStore
+```ts
+interface UserInventoryState {
+  inventories: Record<UserId, Record<GachaId, InventoryByRarity>>;
+  byItemId: Record<ItemId, Array<{ userId: UserId; gachaId: GachaId; rarityId: RarityId; count: number }>>;
+}
+```
+- `inventories[userId][gachaId][rarityId][itemId] = count` で在庫を保持。
+- `addItem`, `incrementCount`, `bulkReplaceItems` などのアクションが呼ばれると `byItemId` キャッシュも更新する。
+
+### 2.3 HitCountStore
+```ts
+interface HitCountState {
+  byItemId: Record<ItemId, number>;
+}
+```
+- リアルタイム貼り付けやガチャシミュレーター結果を元に、抽選ヒット数を蓄積する。
+- `setHitCount(itemId, count)` や `incrementHit(itemId)` が `useRiaguAssignment` の再評価を誘発する。
+
+### 2.4 UserStore
+```ts
+interface UserStoreState {
+  users: Record<UserId, UserCardModel>;
+}
+```
+- `updateUser(userId, patch)` が表示名、アバター色、所属タグを差し替える。
+- 変更後は購読しているコンポーネント（`UserChip`, `UserCard`, `RiaguCard`）へコンテキスト経由で新しい `UserCardModel` が提供される。
+
+### 2.5 RarityStore
+```ts
+interface RarityState {
+  byGachaId: Record<GachaId, Record<RarityId, RarityMeta>>;
+}
+```
+- `emitChange()` は `RarityProvider` 内で購読者に通知する低レイヤーのイベントハブ。`updateRarityMeta` 実行後に呼ばれる。
+
+## 3. セレクタと再計算ロジック
+### 3.1 useRiaguAssignment(riaguId)
+1. `const card = useRiaguCard(riaguId);`
+2. `const inventoryHits = useUserInventoryByItem(card.itemId);`
+   - `inventoryHits` は `UserInventoryStore.byItemId[itemId]` の結果。
+3. `const hitCount = useHitCount(card.itemId);`
+4. `const winners = inventoryHits.map(({ userId, count }) => ({ userId, count: Math.max(count, hitCount > 0 ? 1 : 0) }));`
+   - ガチャヒット数が存在する場合は最低 1 個として扱い、`count` が 0 のユーザーは除外する。
+5. `const totalCount = winners.reduce((sum, winner) => sum + winner.count, 0);`
+6. `const effectiveOrderQty = card.orderHint ?? totalCount;`
+7. `const totalCost = card.unitCost * effectiveOrderQty;`
+8. `return { riaguId, itemId: card.itemId, winners, totalCount, effectiveOrderQty, totalCost };`
+
+### 3.2 useRiaguCard(riaguId)
+- `RiaguStore` を購読し、指定 ID の `RiaguCardModel` を返す。
+- 内部では `useItemCard(card.itemId)` を併用して Item 名称・レアリティを取得。
+
+### 3.3 useUserChip(userId)
+1. `const user = useUserStore(userId);`
+2. `return { displayName: user.displayName, accentColor: user.themeColor, avatarUrl: user.avatarUrl };`
+- `UserChip` はこの hook を利用し、`userId` を渡すだけでレンダーに必要な表示情報を得る。
+
+## 4. 同期フロー
+1. **ユーザー名変更**
+   - `UserCard` で編集 → `UserStore.updateUser` → `users[userId]` が更新 → `UserChip` が再レンダー → `RiaguCard` の獲得者ラベルが即時更新。
+2. **リアルタイム入力 / ガチャ排出**
+   - `RealtimePastePanel` や `GachaSimulator` で結果を入力 → `UserInventoryStore.incrementCount({ userId, gachaId, rarityId, itemId, delta })` → `inventories` と `byItemId` が更新 → `useRiaguAssignment` が再評価 → `winners`・`totalCount`・`effectiveOrderQty`・`totalCost` が更新。
+3. **抽選ヒット更新**
+   - `HitCountStore.setHitCount(itemId, n)` → `useRiaguAssignment` のステップ 4 で `Math.max(count, hitCount ? 1 : 0)` が再計算され、最低保証数が補正される。
+4. **レアリティ設定変更**
+   - `RarityStore.updateRarityMeta(gachaId, rarityId, patch)` → 内部で `emitChange()` → `useRarity(rarityId)` を使う `RiaguCard` が再レンダーし、バッジ色とラベルを更新。
+5. **リアグメタ編集**
+   - `RiaguModal` で原価や発注予定数を更新 → `RiaguStore.updateRiaguMeta` → `useRiaguAssignment` が `effectiveOrderQty` / `totalCost` を即再計算。
+
+## 5. イベント連携
+- `ItemCard.toggleRiagu(itemId)`
+  - on: `RiaguStore.markItemAsRiagu(itemId, meta)` を呼び、`riaguCards` にレコードを作成。
+  - off: `RiaguStore.unmarkRiagu(itemId)` で `riaguCards` / `indexByItemId` を削除し、`RiaguAssignment` の購読も解放する。
+- `AppPersistence.saveDebounced()`
+  - `RiaguStore`, `UserInventoryStore`, `UserStore` の変更をバッチングし、IndexedDB へまとめて書き込む。
+
+## 6. テスト観点
+- **ユニット**: `useRiaguAssignment` にモックしたストア値を与え、`totalCount`・`effectiveOrderQty`・`totalCost` の算出が期待通りか検証。
+- **統合**: Playwright シナリオ「ユーザー名変更 → RiaguCard の UserChip が更新」「ガチャ結果貼り付け → 勝者数・原価タグが更新」。
+- **回帰**: `UserStore.updateUser` と `RarityStore.emitChange()` の同時更新で無限ループが発生しないかを確認する。
+
+## 7. 将来拡張メモ
+- `winners` に `deliveredAt`, `shippingStatus` を追加し配送追跡を行う。
+- `HitCountStore` へ履歴ログを追加し、抽選経緯をタイムライン表示する。
+- WebSocket 等による他クライアント同期時は `UserInventoryStore` と `RiaguStore` の差分パッチをブロードキャストする。


### PR DESCRIPTION
## Summary
- document how UserStore updates propagate into Riagu flows and contrast with rarity emitChange notifications
- detail inventory-driven recalculation and realtime increments in the riagu component plan
- add a dedicated riagu_react_sync_spec covering selectors, stores, and event flows

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e14ccb06b483269fc81c8138802eb5