### PR TITLE
Document edge resolve key flow for blob upload

### DIFF
--- a/doc/blob_upload_react_spec.md
+++ b/doc/blob_upload_react_spec.md
@@ -160,7 +160,7 @@ interface UploadZipResult {
 ### エラーハンドリング
 - `upload` / `resolveEdgeReceive` どちらか失敗時に `BlobUploadError` を投げる。
 - ネットワークキャンセル（`AbortError` 等）はモーダルが握りつぶす。
-- 成功時は `SaveOptionsModalStore.setResult({ kind: 'upload', key, shareUrl, expiresAt })`。
+- 成功時は `SaveOptionsModalStore.setResult({ kind: 'upload', key, shareUrl, expiresAt, pathname, downloadUrl })`。
 
 #### 処理シーケンス
 

--- a/doc/blob_upload_react_spec.md
+++ b/doc/blob_upload_react_spec.md
@@ -134,10 +134,11 @@ interface UploadZipArgs {
   ownerDiscordId: string;       // サービス利用者の Discord ユニークID
 }
 interface UploadZipResult {
-  downloadUrl: string;   // Blob から返却される
-  url: string;           // 同上
-  pathname: string;
-  expiresAt: number;     // /api/receive/token の exp
+  key: string;                  // Edge Function で払い出される 10 桁 ID
+  shareUrl: string;             // `https://<host>/receive?key=XXXXXXXXXX`
+  pathname: string;             // Blob 側の保存パス（重複検知用）
+  downloadUrl: string;          // Blob から返却される署名付き URL
+  expiresAt: string;            // Edge Function が返す ISO-8601
 }
 ```
 1. `ensureCsrf()` … `/api/blob/csrf` を一度だけ叩き、Cookie (`csrf`) を確保。
@@ -149,14 +150,36 @@ interface UploadZipResult {
      - `sanitizePath` は `/[0-9A-Za-z._-]/` 以外の文字を `-` に置換し、先頭/末尾の `-` は削る。結果が空なら `'unknown'`。
    - `clientPayload` に `{ purpose: 'zips', userId, ownerDiscordId, receiverName }` を含める。
    - `pathname` を戻り値から受け取り、`localStorage` 等に控える（重複解析に利用）。
-3. `issueReceiveShareUrl(downloadUrl, fileName)` … `/api/receive/token` に POST。
-   - 期限はデフォルト 7 日。UI で変更しない限り同値。
-4. 共有 URL を `localStorage.setItem('last-upload:' + userId, JSON.stringify({ url, exp }))` に保存。
+3. `resolveEdgeReceive({ pathname, downloadUrl })` … Edge Function `POST /api/receive/edge-resolve` を呼び出す。
+   - リクエストボディ例: `{ pathname, downloadUrl, ownerDiscordId, userId, receiverName }`。
+   - レスポンス: `{ key: 'XXXXXXXXXX', shareUrl: 'https://.../receive?key=XXXXXXXXXX', expiresAt: 'ISO-8601' }`。
+   - `key` は受け取りページ用の 10 桁 ID（後続の `GET /api/receive/edge-resolve?key=` で利用）。
+4. `localStorage.setItem('last-upload:' + userId, JSON.stringify({ key, shareUrl, expiresAt }))` に保存。
+   - 保存データは `{ key: string; shareUrl: string; expiresAt: string; pathname: string }` を想定。`pathname` は重複アップロードの検出用に同時保存。
 
 ### エラーハンドリング
-- `upload` / `issueReceiveShareUrl` どちらか失敗時に `BlobUploadError` を投げる。
+- `upload` / `resolveEdgeReceive` どちらか失敗時に `BlobUploadError` を投げる。
 - ネットワークキャンセル（`AbortError` 等）はモーダルが握りつぶす。
-- 成功時は `SaveOptionsModalStore.setResult({ kind: 'upload', url: shareUrl, expiresAt: exp })`。
+- 成功時は `SaveOptionsModalStore.setResult({ kind: 'upload', key, shareUrl, expiresAt })`。
+
+#### 処理シーケンス
+
+```mermaid
+sequenceDiagram
+  participant SaveOptionsModal
+  participant useBlobUpload
+  participant BlobAPI as Vercel Blob API
+  participant EdgeResolve as POST /api/receive/edge-resolve
+
+  SaveOptionsModal->>useBlobUpload: uploadZip(args)
+  useBlobUpload->>BlobAPI: upload(file, clientPayload)
+  BlobAPI-->>useBlobUpload: { downloadUrl, pathname }
+  useBlobUpload->>EdgeResolve: POST { pathname, downloadUrl, ... }
+  EdgeResolve-->>useBlobUpload: { key, shareUrl, expiresAt }
+  useBlobUpload-->>SaveOptionsModal: { key, shareUrl, downloadUrl, expiresAt }
+```
+
+> Edge Function から返却される `key` および `expiresAt` の型・意味は、受け取り側 React ページ計画書（`doc/receive/receive_page_react_plan.md` §6.1）で定義される `GET /api/receive/edge-resolve` のレスポンスと揃えておく。双方で 10 桁キーと ISO-8601 形式の期限を共通認識とすることで API 契約の齟齬を防ぐ。
 
 ## 6. モーダル連携フロー
 1. `SaveOptionsModal` が開くと `useZipBuilder` を準備。

--- a/doc/modals/save_options_modal_spec.md
+++ b/doc/modals/save_options_modal_spec.md
@@ -41,7 +41,7 @@
 ## 5. 成功時 UI
 - ローカル保存成功: グローバルトーストで完了を通知する。モーダル内の状態は変えない。
 - Blob アップロード成功:
-  - `SaveOptionsModalStore.setResult({ kind: 'upload', url, expiresAt })` を呼び出す。
+  - `SaveOptionsModalStore.setResult({ kind: 'upload', key, shareUrl, expiresAt, pathname, downloadUrl })` を呼び出す。
   - モーダル内に共有 URL カードを表示し、`コピー` ボタンでクリップボードへ複製できる。
   - メッセージセクションの Info バナーを「共有リンクを作成しました」に差し替える。
 
@@ -57,8 +57,11 @@ interface SaveOptionsModalState {
   targetUserId: string | null;
   lastResult?: {
     kind: 'upload';
-    url: string;
-    expiresAt: number;
+    key: string;
+    shareUrl: string;
+    expiresAt: string; // Edge Function が返す ISO-8601
+    pathname: string;
+    downloadUrl?: string; // localStorage には保持しない（共有用リンクのみ保存）
   } | null;
   open: (userId: string) => void;
   close: () => void;
@@ -66,6 +69,7 @@ interface SaveOptionsModalState {
 }
 ```
 - `lastResult` は最新の Blob アップロード結果。React ルートの `useEffect` で localStorage (`last-upload:<userId>`) と同期する。
+  - 保存フォーマットは `doc/blob_upload_react_spec.md` §5 で定義される `{ key, shareUrl, expiresAt, pathname }`。
 - `open` / `close` は `openSaveOptionsModal` / `closeSaveOptionsModal` 経由で公開する。
 # 保存オプションモーダル (SaveOptionsDialog) 仕様書
 

--- a/doc/receive/receive_page_react_plan.md
+++ b/doc/receive/receive_page_react_plan.md
@@ -187,6 +187,7 @@ src/receive/
   - `GET /api/receive/edge-resolve?key=XXXXXXXXXX`
   - 成功レスポンス: `{ ok:true, blobName:string, downloadUrl:string, displayName:string, expiresAt:string, message?:string, theme?:object }`
   - 404/410 時は `{ ok:false, code:'NOT_FOUND'|'EXPIRED' }`。
+- 上記フィールド構成は `doc/blob_upload_react_spec.md` の `POST /api/receive/edge-resolve`（アップロード完了時に 10 桁キーと `expiresAt` を返却）と対になる契約であり、共有 URL 生成と受け取りページ解決の双方で `key` / `expiresAt` を同一フォーマット（10 桁英数字 + ISO-8601）として扱う。
 - 既存の `/api/receive/resolve` は互換性のため残し、React ページでは新 API を優先。旧トークン `t` を受け取った際は既存 API をフォールバックで呼ぶ。
 
 ### 6.2 `metadata.json` 仕様案


### PR DESCRIPTION
## Summary
- update the React blob upload spec to describe posting to the edge resolve API, receiving the 10-character key, and storing key-based metadata
- add a sequence diagram plus revised interfaces and localStorage format to match the new flow
- annotate the receive page React plan to note the shared API contract between upload and resolve endpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e0b31f988326beadd1c784590c62